### PR TITLE
Serialize numeric values even if zero

### DIFF
--- a/tests/protocol/test_json_protocol.py
+++ b/tests/protocol/test_json_protocol.py
@@ -31,6 +31,14 @@ class JSONProtocolTestCase(TestCase):
         self.assertEqual(e.exception.description, "'bad' is not of type 'object'")
         self.assertEqual(e.exception.path, [])
 
+    def test_encode_zero_numeric(self):
+        class Pet(Message):
+            cuteness: float
+
+        protocol = JSONProtocol(Pet)
+        self.assertEqual(protocol.encode(Pet(0.0)), {'cuteness': 0.0})
+        self.assertEqual(protocol.decode({'cuteness': 0.0}), Pet(0.0))
+
     def test_encode_with_field_mask(self):
         class Pet(Message):
             sound: str

--- a/tests/protocol/test_json_protocol.py
+++ b/tests/protocol/test_json_protocol.py
@@ -206,7 +206,7 @@ class JSONProtocolTestCase(TestCase):
         self.assertEqual(protocol.decode({}), Pet())
 
         self.assertEqual(protocol.pack(Pet()), b'{}')
-        self.assertEqual(protocol.pack(Pet([])), b'{}')
+        self.assertEqual(protocol.pack(Pet([])), b'{"sounds":[]}')
         self.assertEqual(protocol.pack(Pet(['hiss!'])), b'{"sounds":["hiss!"]}')
 
         self.assertEqual(protocol.unpack(b'{}'), Pet())

--- a/tests/rpc/comms/test_aiohttp_server.py
+++ b/tests/rpc/comms/test_aiohttp_server.py
@@ -59,7 +59,7 @@ class AioHTTPSimpleServerTestCase(AioHTTPTestCase):
         response = await self.client.post("/snake", data=json.dumps({}))
 
         self.assertEqual(200, response.status)
-        self.assertEqual({'id': 1, 'size': 2}, await response.json())
+        self.assertEqual({'id': 1, 'name': '', 'size': 2}, await response.json())
 
         response = await self.client.post("/snake", data=json.dumps({'name': 'Snek', 'size': 9001}))
 

--- a/venom/message.py
+++ b/venom/message.py
@@ -110,7 +110,7 @@ class Message(Mapping, metaclass=MessageMeta):
     def __repr__(self):
         parts = []
         for key in self.__fields__.keys():
-            if key in self._values and self._values[key]:
+            if key in self._values and self._values[key] is not None:
                 parts.append('{}={}'.format(key, repr(self._values[key])))
         return '{}({})'.format(self.__meta__.name, ', '.join(parts))
 

--- a/venom/protocol/transcode.py
+++ b/venom/protocol/transcode.py
@@ -100,7 +100,7 @@ class DictMessageTranscoder(MessageTranscoder):
         for (name, json_name), encode in self.field_encoders.items():
             try:
                 value = message[name]
-                if value:
+                if value is not None:
                     obj[json_name] = encode(value)
             except KeyError:
                 pass


### PR DESCRIPTION
Referring back to [this commit](https://github.com/biosustain/venom/commit/0e147eb772aed0363ee20778c342589aadf6925d), any value that does not pass the [truth value test](https://docs.python.org/3/library/stdtypes.html#truth-value-testing) is not serialized. This includes zeroed numbers (`0`, `0.0`, etc) which should be serialized.

This fix suggestion checks explicitly if the value is numeric and if so, always includes it.